### PR TITLE
Making the path of the salt source a command line option for docker containers

### DIFF
--- a/salttesting/parser/__init__.py
+++ b/salttesting/parser/__init__.py
@@ -672,9 +672,9 @@ class SaltTestingParser(optparse.OptionParser):
         ]
 	if self.options.docked_salt_source:
             docker_call.append('-v')
-            docker_call.append('{0}:/usr/lib/python2.7/dist-packages/salt'.format(
-                self.options.docked_salt_source
-            ))
+            docker_call.append(
+                '{0}:/pysource/salt:ro'.format(self.options.docked_salt_source)
+            )
 
 	docker_call.extend(
             ['-e',


### PR DESCRIPTION
We were looking into writing both unit and integration tests for our own custom modules and states and thought it was a good idea to be using salts own framework in as a large extent as possible, we ran into the issue that the integration tests inside a docker container required the tests/ folder for the test runner to be adjacent to the salt source code, which it wasn't for us since we deploy custom states through the salt fileserver. We applied this patch to be able to run our own subset of integration tests against the salttesting docker containers using the salt test runner.

It is a bit ugly, though with a hard coded inclusion path destination. Maybe you want to make sure that the python interpreter is reading from the destination path in question as well. Right now it is only working for Debian/Ubuntu distributions running python 2.7. Suggestions on how to best fix this are welcome!

Addresses issue #12
