### PR TITLE
run-cloud-providers option added

### DIFF
--- a/salttesting/helpers.py
+++ b/salttesting/helpers.py
@@ -36,11 +36,11 @@ def destructiveTest(func):
     return wrap
 
 
-def cloudProviderTest(func):
+def expensiveTest(func):
     @wraps(func)
     def wrap(cls):
-        if os.environ.get('CLOUD_PROVIDER_TESTS', 'False').lower() == 'false':
-            cls.skipTest('Cloud provider tests are disabled')
+        if os.environ.get('EXPENSIVE_TESTS', 'False').lower() == 'false':
+            cls.skipTest('Expensive tests are disabled')
         return func(cls)
     return wrap
 

--- a/salttesting/parser/__init__.py
+++ b/salttesting/parser/__init__.py
@@ -92,7 +92,7 @@ def print_header(header, sep='~', top=True, bottom=True, inline=False,
 class SaltTestingParser(optparse.OptionParser):
     support_docker_execution = False
     support_destructive_tests_selection = False
-    support_cloud_provider_tests = False
+    support_expensive_tests_selection = False
     source_code_basedir = None
 
     _known_interpreters = {
@@ -154,14 +154,14 @@ class SaltTestingParser(optparse.OptionParser):
                       'or removing users from your system for example. '
                       'Default: %default')
             )
-        if self.support_cloud_provider_tests is True:
+        if self.support_expensive_tests_selection is True:
             self.test_selection_group.add_option(
-                '--run-cloud-providers',
+                '--run-expensive',
                 action='store_true',
                 default=False,
-                help=('Run cloud provider tests. These tests create and delete '
-                      'instances on cloud providers. Must provide valid credentials '
-                      'in salt/tests/integration/files/conf/cloud.*.d to run tests.')
+                help=('Run expensive tests. Expensive tests are any tests that, '
+                      'once configured, cost money to run, such as creating or '
+                      'destroying cloud instances on a cloud provider.')
             )
 
         self.test_selection_group.add_option(
@@ -354,10 +354,10 @@ class SaltTestingParser(optparse.OptionParser):
             # destructive tests should be executed or not.
             os.environ['DESTRUCTIVE_TESTS'] = str(self.options.run_destructive)
 
-        if self.support_cloud_provider_tests:
+        if self.support_expensive_tests_selection:
             # Set the required environment variable in order to know if
-            # cloud provider tests should be exevuted or not.
-            os.environ['CLOUD_PROVIDER_TESTS'] = str(self.options.run_cloud_providers)
+            # expensive tests should be executed or not.
+            os.environ['EXPENSIVE_TESTS'] = str(self.options.run_expensive)
 
     def validate_options(self):
         '''


### PR DESCRIPTION
@s0undt3ch - I have been writing some initial tests for testing basic Salt-Cloud functionality. The idea is to test basic "create an instance" and "delete the instance" functionality with each provider. @techhat wanted the tests to be off by default, so I have made a "--run-cloud-providers" flag with a decorator, similar to "--run-destructive". I don't think we want these on all of the time on Jenkins, but available to run as needed to catch API changes and such.

Can you take a look at the changes here as well as my forth-coming PR on salt? Feedback is much appreciated! :)
