### PR TITLE
backport mock_open from py3 unittest.mock

### DIFF
--- a/salttesting/mock.py
+++ b/salttesting/mock.py
@@ -11,6 +11,7 @@
 '''
 
 from __future__ import absolute_import
+import sys
 
 try:
     from mock import (
@@ -24,7 +25,6 @@ try:
         FILTER_DIR,
         NonCallableMock,
         NonCallableMagicMock,
-        mock_open,
         PropertyMock
     )
     NO_MOCK = False
@@ -73,3 +73,85 @@ if NO_MOCK is False:
     except ImportError:
         NO_MOCK = True
         NO_MOCK_REASON = 'you need to upgrade your mock version to >= 0.8.0'
+
+
+if sys.version_info[0] >= 3:
+    from mock import mock_open
+else:
+    # backport mock_open from the python 3 unittest.mock library so that we can
+    # mock read, readline, readlines, and file iteration properly
+
+    file_spec = None
+
+    def _iterate_read_data(read_data):
+        # Helper for mock_open:
+        # Retrieve lines from read_data via a generator so that separate calls to
+        # readline, read, and readlines are properly interleaved
+        data_as_list = ['{}\n'.format(l) for l in read_data.split('\n')]
+
+        if data_as_list[-1] == '\n':
+            # If the last line ended in a newline, the list comprehension will have an
+            # extra entry that's just a newline.  Remove this.
+            data_as_list = data_as_list[:-1]
+        else:
+            # If there wasn't an extra newline by itself, then the file being
+            # emulated doesn't have a newline to end the last line  remove the
+            # newline that our naive format() added
+            data_as_list[-1] = data_as_list[-1][:-1]
+
+        for line in data_as_list:
+            yield line
+
+    def mock_open(mock=None, read_data=''):
+        """
+        A helper function to create a mock to replace the use of `open`. It works
+        for `open` called directly or used as a context manager.
+
+        The `mock` argument is the mock object to configure. If `None` (the
+        default) then a `MagicMock` will be created for you, with the API limited
+        to methods or attributes available on standard file handles.
+
+        `read_data` is a string for the `read` methoddline`, and `readlines` of the
+        file handle to return.  This is an empty string by default.
+        """
+        def _readlines_side_effect(*args, **kwargs):
+            if handle.readlines.return_value is not None:
+                return handle.readlines.return_value
+            return list(_data)
+
+        def _read_side_effect(*args, **kwargs):
+            if handle.read.return_value is not None:
+                return handle.read.return_value
+            return ''.join(_data)
+
+        def _readline_side_effect():
+            if handle.readline.return_value is not None:
+                while True:
+                    yield handle.readline.return_value
+            for line in _data:
+                yield line
+
+
+        global file_spec
+        if file_spec is None:
+            file_spec = file
+
+        if mock is None:
+            mock = MagicMock(name='open', spec=open)
+
+        handle = MagicMock(spec=file_spec)
+        handle.__enter__.return_value = handle
+
+        _data = _iterate_read_data(read_data)
+
+        handle.write.return_value = None
+        handle.read.return_value = None
+        handle.readline.return_value = None
+        handle.readlines.return_value = None
+
+        handle.read.side_effect = _read_side_effect
+        handle.readline.side_effect = _readline_side_effect()
+        handle.readlines.side_effect = _readlines_side_effect
+
+        mock.return_value = handle
+        return mock


### PR DESCRIPTION
MagicMock's implementation of mock_open cannot handle iterating over a file without some ugly hackery, so let's just backport the py3's implementation (MagicMock seems to have been incorporated into the py3 standard library at unittest.mock).