### PR TITLE
Fix py3 failure in RuntimeVars.__getattribute__()

### DIFF
--- a/salttesting/runtests.py
+++ b/salttesting/runtests.py
@@ -534,9 +534,9 @@ class RuntimeVars(object):
             yield name, value
 
     def __getattribute__(self, name):
-        if name in object.__getattribute__(self, '__self_attributes__'):
-            return object.__getattribute__(self, name)
-        return object.__getattribute__(self, '_vars')[name]
+        if name in object.__getattribute__(self, '_vars'):
+            return object.__getattribute__(self, '_vars')[name]
+        return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
         if getattr(self, '_locked', False) is True:


### PR DESCRIPTION
Under python 3.4, the unit test loader does some tests on each object in a module to identify test cases.  When the loader tests `RUNTIME_VARS`, the call to `isinstance()` raises an exception because it cannot find the object's `__class__` attribute. See `TestLoader.loadTestsFromModule()` in `unittest/loader.py`.

This change lets `__getattribute__()` find the attributes it inherits fromits base class (`object`).

```
$ python runtests.py -u
[...]
Traceback (most recent call last):
  File "runtests.py", line 476, in <module>
    main()
  File "runtests.py", line 463, in main
    status = parser.run_unit_tests()
  File "runtests.py", line 431, in run_unit_tests
    os.path.join(TEST_DIR, 'unit'), 'Unit', '*_test.py'
  File "/home/msteed/salt-testing/salttesting/parser/__init__.py", line 482, in run_suite
    tests = loader.discover(path, suffix, self.testsuite_directory)
  File "/usr/lib/python3.4/unittest/loader.py", line 264, in discover
    tests = list(self._find_tests(start_dir, pattern))
  File "/usr/lib/python3.4/unittest/loader.py", line 349, in _find_tests
    namespace=namespace)
  File "/usr/lib/python3.4/unittest/loader.py", line 328, in _find_tests
    yield self.loadTestsFromModule(module)
  File "/usr/lib/python3.4/unittest/loader.py", line 78, in loadTestsFromModule
    if isinstance(obj, type) and issubclass(obj, case.TestCase):
  File "/home/msteed/salt-testing/salttesting/runtests.py", line 539, in __getattribute__
    return object.__getattribute__(self, '_vars')[name]
KeyError: '__class__'
```