### PR TITLE
Delay assignment of Mock = MagicMock

### DIFF
--- a/salttesting/mock.py
+++ b/salttesting/mock.py
@@ -46,8 +46,6 @@ except ImportError:
 
     # Let's not fail on imports by providing fake objects and classes
 
-    Mock = MagicMock
-
     class MagicMock(object):
 
         __name__ = '{0}.fakemock'.format(__name__)
@@ -64,6 +62,7 @@ except ImportError:
         def __call__(self, *args, **kwargs):
             return self
 
+    Mock = MagicMock
     patch = MagicMock()
     sentinel = object()
     DEFAULT = object()


### PR DESCRIPTION
Prevents failure when mock is absent, since MagicMock is not defined yet.