### PR TITLE
Add python3 support flag

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -516,6 +516,8 @@ def get_minion_python_executable(options):
     try:
         python_executable = json.loads(stdout.strip())
         python_executable = python_executable[options.vm_name]
+        if options.test_with_python3:
+            python_executable = '/usr/bin/python3'
         setattr(options, 'minion_python_executable', python_executable)
         save_state(options)
         return python_executable

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -234,6 +234,9 @@ def build_pillar_data(options, convert_to_yaml=True):
     if options.test_with_new_coverage:
         pillar['new_coverage'] = True
 
+    if options.test_with_python3:
+        pillar['py3'] = True
+
     if convert_to_yaml is True:
         return to_cli_yaml(pillar)
     return pillar
@@ -980,6 +983,12 @@ def main():
         default=False,
         action='store_true',
         help='When running the tests default command, run coverage using a more inclusive approach.'
+    )
+    testing_source_options.add_argument(
+        '--test-with-python3',
+        default=False,
+        action='store_true',
+        help='Use python3 instead of python2 to run the test suite'
     )
     testing_source_options.add_argument(
         '--test-prep-sls',


### PR DESCRIPTION
This lets the salt-jenkins-build pass in the py3 pillar to allow the test suite to run with python3