### PR TITLE
Fix PYTHONPATH error in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# PyCharm
+.idea

--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -24,6 +24,9 @@ import logging
 import subprocess
 from datetime import datetime, timedelta
 
+# Import Salt Libs
+import salt.utils
+
 # Import salt testing libs
 from salttesting.unit import TestCase
 from salttesting.helpers import RedirectStdStreams
@@ -204,7 +207,12 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
             return False
 
         python_path = os.environ.get('PYTHONPATH', None)
-        cmd = 'PYTHONPATH='
+
+        if salt.utils.is_windows():
+            cmd = 'set PYTHONPATH='
+        else:
+            cmd = 'PYTHONPATH='
+
         if python_path is not None:
             cmd += '{0}:'.format(python_path)
 


### PR DESCRIPTION
Windows requires the set command to set environment variables.