### PR TITLE
Revert "Fix PYTHONPATH error in Windows"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,3 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-
-# PyCharm
-.idea

--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -24,9 +24,6 @@ import logging
 import subprocess
 from datetime import datetime, timedelta
 
-# Import Salt Libs
-import salt.utils
-
 # Import salt testing libs
 from salttesting.unit import TestCase
 from salttesting.helpers import RedirectStdStreams
@@ -207,12 +204,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
             return False
 
         python_path = os.environ.get('PYTHONPATH', None)
-
-        if salt.utils.is_windows():
-            cmd = 'set PYTHONPATH='
-        else:
-            cmd = 'PYTHONPATH='
-
+        cmd = 'PYTHONPATH='
         if python_path is not None:
             cmd += '{0}:'.format(python_path)
 


### PR DESCRIPTION
Reverts saltstack/salt-testing#62

@twangboy This was reverted because it was breaking the test suite. 