### PR TITLE
Fix PYTHONPATH error in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Pycharm
+.idea

--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -204,7 +204,12 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
             return False
 
         python_path = os.environ.get('PYTHONPATH', None)
-        cmd = 'PYTHONPATH='
+
+        if sys.platform.startswith('win'):
+            cmd = 'set PYTHONPATH='
+        else:
+            cmd = 'PYTHONPATH='
+
         if python_path is not None:
             cmd += '{0}:'.format(python_path)
 


### PR DESCRIPTION
Fixes PYTHONPATH setting on windows without using salt.utils