### PR TITLE
Set a default timeout for run_script

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -195,7 +195,8 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                    arg_str,
                    catch_stderr=False,
                    with_retcode=False,
-                   timeout=None,
+                   # FIXME A timeout of zero or disabling timeouts may not return results!
+                   timeout=15,
                    raw=False):
         '''
         Execute a script with the given argument string


### PR DESCRIPTION
It would appear that popen is not blocking the process return without a pipe.

The communicate() should be doing this, but we might be hitting a bug in popen?

Therefore, set a default timeout as a workaround. The better solution would be to
figure out why we aren't blocking. I have mentioned that as a FIXME.