### PR TITLE
Check for file path type before calling os.remove()

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -353,7 +353,13 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
         finally:
             try:
                 if os.path.exists(tmp_file.name):
-                    os.remove(tmp_file.name)
+                    if isinstance(tmp_file.name, str):
+                        # tmp_file.name is an int when using SpooledTemporaryFiles
+                        # int types cannot be used with os.remove() in Python 3
+                        os.remove(tmp_file.name)
+                    else:
+                        # Clean up file handles
+                        tmp_file.close()
                 process.terminate()
             except OSError as err:
                 # process already terminated


### PR DESCRIPTION
When running the test suite with Python 3, we need to check for the type of a file path before calling os.remove(). In PY3, os.path.exists() returns true as there are still open file descriptors at this point, but tmp_file.name is an integer instead of a string, causing os.remove to stacktrace.

This change checks for the the tmp_file.name type and closes the file handle.