### PR TITLE
Let's decode the file read right away

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -283,7 +283,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                 if process.returncode is not None:
                     break
         tmp_file.seek(0)
-        out = tmp_file.read()
+        out = tmp_file.read().decode()
         if catch_stderr:
             if sys.version_info < (2, 7):
                 # On python 2.6, the subprocess'es communicate() method uses


### PR DESCRIPTION
Instead of decoding all of the byte objects in salt's test suite files

Refs the change made in #65 where SpooledTemporaryFiles are read with `w+b` by default. Instead of tracking down all of the places byte strings need to be decoded in Salt proper, let's just do it sooner in salttesting.

An example of `decode()` being used in salt's instegration suite is in https://github.com/saltstack/salt/pull/34990. Many more decodes will be needed throughout that file and this file if we wait to decode. (And that change will need to be reverted in https://github.com/saltstack/salt/pull/34990 if this is merged.)