### PR TITLE
Handle the decode function better when reading in the spooled tmp file

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -283,7 +283,16 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                 if process.returncode is not None:
                     break
         tmp_file.seek(0)
-        out = tmp_file.read().decode()
+
+        if sys.version_info > (2,):
+            try:
+                out = tmp_file.read().decode(__salt_system_encoding__)
+            except NameError:
+                # Let's cross our fingers and hope for the best
+                out = tmp_file.read().decode('utf-8')
+        else:
+            out = tmp_file.read()
+
         if catch_stderr:
             if sys.version_info < (2, 7):
                 # On python 2.6, the subprocess'es communicate() method uses

--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -31,6 +31,12 @@ from salttesting.helpers import RedirectStdStreams
 from salttesting.runtests import RUNTIME_VARS
 from salttesting.mixins import AdaptedConfigurationTestCaseMixIn, SaltClientTestCaseMixIn
 
+# Try to import salt: needed for __salt_system_encoding__ reference
+try:
+    import salt
+except ImportError:
+    pass
+
 STATE_FUNCTION_RUNNING_RE = re.compile(
     r'''The function (?:"|')(?P<state_func>.*)(?:"|') is running as PID '''
     r'(?P<pid>[\d]+) and was started at (?P<date>.*) with jid (?P<jid>[\d]+)'


### PR DESCRIPTION
Refs #72

When reading in the spooled tmp file, we must decode the binary data immediately. However, we must handle this differently in Py2 and 3. For Py3, we will try to use salt's system encoding dunder if possible, and then fall back to utf-8 for now. In Py2, we're not reading for everything to be unicode yet in Salt, so we'll keep these as string objects until we can make a full switch.

Thanks to @s0undt3ch for the pointers here to not decode straight to ascii inadvertently.