### PR TITLE
Fix typo in run_run_plus, add fun name and jid to return

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -154,7 +154,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
         Execute Salt run and the salt run function and return the data from
         each in a dict
         '''
-        ret = {}
+        ret = {'fun': fun}
         ret['out'] = self.run_run(
             '{0} {1} {2}'.format(options, fun, ' '.join(arg)), catch_stderr=kwargs.get('catch_stderr', None)
         )
@@ -168,7 +168,11 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
         opts.update({'doc': False, 'fun': fun, 'arg': arg})
         with RedirectStdStreams():
             runner = salt.runner.Runner(opts)
-            ret['fun'] = runner.run()
+            ret['return'] = runner.run()
+            try:
+                ret['jid'] = runner.jid
+            except AttributeError:
+                ret['jid'] = None
         return ret
 
     def run_key(self, arg_str, catch_stderr=False, with_retcode=False):


### PR DESCRIPTION
This fixes a typo as well as adds the jid to the return (to be used in
some tests I am about to write where I need to check the job cache after
a runner is executed).

I am making similar changes in the run_run_plus func in
tests/integration/__init__.py on the salt repo.