### PR TITLE
Interactive support

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -358,13 +358,18 @@ def bootstrap_cloud_minion(options):
         '-l', options.log_level,
         '--script-args="{0}"'.format(' '.join(script_args)),
         '-p', options.vm_source,
+        '--out=yaml',
         options.vm_name
     ]
     if options.no_color:
         cmd.append('--no-color')
-    exitcode = run_command(cmd, options)
+    cloud_stdout, _, exitcode = run_command(cmd, options, return_output=True)
     if exitcode == 0:
         setattr(options, 'salt_minion_bootstrapped', 'yes')
+        # Strip off the header
+        clean_stdout = '\n'.join(cloud_stdout.split('\n')[2:])
+        print('IP', yaml.load(clean_stdout)['public_ips'][0].split()[0].encode())
+        setattr(options, 'minion_ip_address', yaml.load(clean_stdout)['public_ips'][0].split()[0].encode())
     return exitcode
 
 


### PR DESCRIPTION
This PR allow you to spin up a VM that looks exactly like the one Jenkins would use but then it allows you to SSH to it and interact with it.

To use this, you must first have cloud profiles and cloud maps configured. Then, a sample command might be:

`salt-jenkins-build  --cloud-deploy --test-prep-sls=git.salt --vm-source=linode_cent7 --test-interactive -ldebug`

At this point, salt-cloud will request a new VM and bootstrap it with Salt. Once up, it will use salt-ssh to log into the VM and it will use GitFS to pull down the Jenkins states and execute them.

There are a number of TODOs. I'm submitting this PR just as a starting point and it's very incomplete.

* Needs to print out details about the VM after it's provisioned. Right now you have to search through the logs a bit to find the IP address.

* It would be much better and faster if we spun up the VM without running bootstrap at all. I cannot seem to find any indication that salt-cloud supports this. If anybody can tell me how, it would improve things dramatically.

* You may need to set `display_ssh_output: False` in your `/etc/salt/cloud` config. I have tried to make it so that this is not necessary but results are mixed.

* The largest problem here is a fundamental limitation of salt-cloud, which is that if you're just looking to stdout to get your structured data (like a return) you might get all sorts of `print`s and other stuff mixed in. I have tried to account for this but it's quite brittle. It would be good if salt-cloud did this but for now we might have to continue to tweak this to get it quite right.