### PR TITLE
Don't execute the runner twice in run_run_plus

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -149,7 +149,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                                                  async_flag=' --async' if async else '')
         return self.run_script('salt-run', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr)
 
-    def run_run_plus(self, fun, options='', *arg, **kwargs):
+    def run_run_plus(self, fun, *arg, **kwargs):
         '''
         Execute Salt run and the salt run function and return the data from
         each in a dict

--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -151,8 +151,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
 
     def run_run_plus(self, fun, *arg, **kwargs):
         '''
-        Execute Salt run and the salt run function and return the data from
-        each in a dict
+        Execute the runner function and return the return data and output in a dict
         '''
         ret = {'fun': fun}
 

--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -154,19 +154,13 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
         Execute Salt run and the salt run function and return the data from
         each in a dict
         '''
-        cmd = '{0} {1} {2}'.format(options, fun, ' '.join(arg))
-        for key, value in six.iteritems(kwargs):
-            cmd += ' {0}={1}'.format(key, _quote(value))
-
         ret = {'fun': fun}
-        ret['out'] = self.run_run(
-            cmd,
-            catch_stderr=kwargs.get('catch_stderr', None)
-        )
 
         # Late import
         import salt.config
+        import salt.output
         import salt.runner
+        from salt.ext.six.moves import cStringIO
 
         opts = salt.config.master_config(
             self.get_config_file_path('master')
@@ -185,6 +179,17 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                 ret['jid'] = runner.jid
             except AttributeError:
                 ret['jid'] = None
+
+        # Compile output
+        # TODO: Support outputters other than nested
+        opts['color'] = False
+        opts['output_file'] = cStringIO()
+        try:
+            salt.output.display_output(ret['return'], opts=opts)
+            ret['out'] = opts['output_file'].getvalue()
+        finally:
+            opts['output_file'].close()
+
         return ret
 
     def run_key(self, arg_str, catch_stderr=False, with_retcode=False):


### PR DESCRIPTION
Instead, compile output by executing salt.output.display_output() on the
return data obtained from executing the runner via the Python API.