### PR TITLE
Change signal handling on cleanup

### DIFF
--- a/salttesting/helpers.py
+++ b/salttesting/helpers.py
@@ -1135,8 +1135,10 @@ def terminate_process_pid(pid, only_children=False):
                         _children.remove(child)
                 except psutil.NoSuchProcess:
                     _children.remove(child)
-
-        kill_children([child for child in children if child.is_running() and not any(sys.argv[0] in cmd for cmd in child.cmdline())])
+        try:
+            kill_children([child for child in children if child.is_running() and not any(sys.argv[0] in cmd for cmd in child.cmdline())])
+        except psutil.AccessDenied:
+            kill_children(children)
 
         if children:
             psutil.wait_procs(children, timeout=3, callback=lambda proc: kill_children(children, kill=True))


### PR DESCRIPTION
* Check for unknown processes and handle that condition

* Modify the shutdown routine to be more aggressive. By the time we hit this, we have already been through several iterations of trying to signal the process nicely. There is no sense at this point in trying to do anything but send SIGTERM. So, now we do so immediately and retry up to twice more. We also check to ensure that we do not attempt to kill ourselves or the logger for the runtests script, since this will stacktrace and cause unpredicitable behavior, including possible failures to exit or inconsistent logging.