### PR TITLE
more parallels fixes and enhancements

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -97,7 +97,12 @@ class GetBranchAction(GitHubAction):
     Load the required branch information
     '''
     def __call__(self, parser, namespace, values, option_string=None):
-        url = 'https://api.github.com/repos/saltstack/salt/branches/{0}'.format(values)
+        # Get a branch from a different GitHub account if requested
+        if ':' in values:
+            account, branch = values.split(':', 1)
+        else:
+            account, branch = 'saltstack', values
+        url = 'https://api.github.com/repos/{0}/salt/branches/{1}'.format(account, branch)
         branch_details = self.get_github_data(url, parser, namespace, values, option_string=option_string)
         setattr(namespace, 'branch_git_commit', branch_details['commit']['sha'])
 # <---- Argparse Custom Actions --------------------------------------------------------------------------------------
@@ -1325,7 +1330,9 @@ def get_args():
         type=str,
         action=GetBranchAction,
         default='develop',
-        help='Include the branch information in parseable output'
+        help='Include the branch information in parseable output.  A GitHub'
+             ' account/org other than saltstack can be specified by prefixing'
+             ' it as <account>:<branch>'
     )
 
     # SSH Options

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -513,13 +513,13 @@ def bootstrap_parallels_minion(options):
         '''
         # Ensure source VM is reverted to stopped snapshot since running VMs
         # cannot be cloned
-        source_state = run_command(_prl_cmd('state', options.vm_source),
+        source_state = run_command(_prl_cmd('status', options.vm_source),
                                             options,
                                             return_output=True)[0]
-        if source_state == 'running':
+        if 'running' in source_state:
             run_command(_prl_cmd('revert_snapshot', options.vm_source, options.vm_snapshot), options)
             # Wait template VM is reverted to snapshot (stopped state)
-            if _repeat(_prl_cmd('state', options.vm_source), 'stopped') != 0:
+            if _repeat(_prl_cmd('status', options.vm_source), 'stopped') != 0:
                 return 1
 
         # Clone source VM
@@ -539,7 +539,7 @@ def bootstrap_parallels_minion(options):
         if 'stopped' in stat_out:
             run_command(_prl_cmd('start', options.vm_name), options)
             # Wait for prlctl to start VM
-            if _repeat(_prl_cmd('state', options.vm_name), 'running') != 0:
+            if _repeat(_prl_cmd('status', options.vm_name), 'running') != 0:
                 return 1
             return 0
         else:


### PR DESCRIPTION
- Wait for salt package download on parallels: when the network is congested, the download outlasts salt's timeout somehow, so rather than fail the test run, check the download hash until it matches.
- allow branch info from other GitHub accounts: such as `jfindlay:mac_branch`.  This is useful for setting up custom jenkins test runs against unofficial branches to allow more integrated testing of changes before needing to merge the changes into the official repo.
- use `status` rather than `state` saltstack/salt#36166