### PR TITLE
Fix major performance issue

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -17,6 +17,7 @@ import os
 import re
 import sys
 import json
+import time
 import stat
 import errno
 import signal
@@ -284,7 +285,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
             term_sent = False
             while True:
                 process.poll()
-
+                time.sleep(0.1)
                 if datetime.now() > stop_at:
                     if term_sent is False:
                         # Kill the process group since sending the term signal


### PR DESCRIPTION
We were in a constant loop polling and calculating the time. Tracing the process showed constant stats of `/etc/localtime`.  It was driving the test runner to consume all the CPU power.

By adding a small sleep, I decreased the test time for salt module from 27 minutes to about four and a half.