### PR TITLE
Discover ext dirs

### DIFF
--- a/salttesting/parser/__init__.py
+++ b/salttesting/parser/__init__.py
@@ -494,19 +494,28 @@ class SaltTestingParser(optparse.OptionParser):
                     shutil.rmtree(path)
 
     def run_suite(self, path, display_name, suffix='[!_]*.py',
-                  load_from_name=False):
+                  load_from_name=False, additional_test_dirs=None):
         '''
         Execute a unit test suite
         '''
+        loaded_custom = False
         loader = TestLoader()
         try:
             if load_from_name:
                 tests = loader.loadTestsFromName(display_name)
             else:
-                tests = loader.discover(path, suffix, self.testsuite_directory)
+                if self.testsuite_directory.startswith(path):
+                    tests = loader.discover(path, suffix, self.testsuite_directory)
+                else:
+                    tests = loader.discover(path, suffix)
+                    loaded_custom = True
         except (AttributeError, ImportError):
             print('Could not locate test \'{0}\'. Exiting.'.format(display_name))
-            sys.exit(1)
+
+        if additional_test_dirs and not loaded_custom:
+            for test_dir in additional_test_dirs:
+                additional_tests = loader.discover(test_dir, suffix, test_dir)
+                tests.addTests(additional_tests)
 
         header = '{0} Tests'.format(display_name)
         print_header('Starting {0}'.format(header),

--- a/salttesting/parser/__init__.py
+++ b/salttesting/parser/__init__.py
@@ -511,6 +511,7 @@ class SaltTestingParser(optparse.OptionParser):
                     loaded_custom = True
         except (AttributeError, ImportError):
             print('Could not locate test \'{0}\'. Exiting.'.format(display_name))
+            sys.exit(1)
 
         if additional_test_dirs and not loaded_custom:
             for test_dir in additional_test_dirs:


### PR DESCRIPTION
This provides the groundwork for allowing users to maintain their own test infrastructure and leverage salt-testing to do all of the acceptance testing for their salt states and modules.