### PR TITLE
Fix logic error in path detection

### DIFF
--- a/salttesting/parser/__init__.py
+++ b/salttesting/parser/__init__.py
@@ -504,7 +504,7 @@ class SaltTestingParser(optparse.OptionParser):
             if load_from_name:
                 tests = loader.loadTestsFromName(display_name)
             else:
-                if self.testsuite_directory.startswith(path):
+                if additional_test_dirs is None or self.testsuite_directory.startswith(path):
                     tests = loader.discover(path, suffix, self.testsuite_directory)
                 else:
                     tests = loader.discover(path, suffix)


### PR DESCRIPTION
I made an error in 772b8e0. This correctly sets the loader path.

Fixes an issue where the shell tests would bail out.