### PR TITLE
Update option to use full namespec offered by pip for SaltTesting installs

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -250,8 +250,8 @@ def build_pillar_data(options, convert_to_yaml=True):
         pillar['bootstrap_salt_url'] = options.bootstrap_salt_url
     if options.bootstrap_salt_commit is not None:
         pillar['bootstrap_salt_commit'] = options.bootstrap_salt_commit
-    if options.salttesting_version is not None:
-        pillar['salttesting_version'] = options.salttesting_version
+    if options.salttesting_namespec is not None:
+        pillar['salttesting_namespec'] = options.salttesting_namespec
 
     # Build package pillar data
     if options.package_source_dir:
@@ -1510,9 +1510,11 @@ def get_args():
         default=None,
         help='The testing git commit to track')
     testing_source_options.add_argument(
-        '--salttesting-version',
+        '--salttesting-namespec',
         default=None,
-        help='The version of salttesting to be installed into the test environment. i.e. 2016.7.22')
+        help='The name specifier used by pip to install salttesting, i.e.'
+             ' salttesting==2016.9.7 or'
+             ' git+https://github.com/saltstack/salt-testing.git@develop#egg=SaltTesting')
     testing_source_options.add_argument(
         '--test-pillar',
         default=[],


### PR DESCRIPTION
Needed to be able to install both `salttesting==2016.9.7` and `git+https://github.com/saltstack/salt-testing@develop#egg=SaltTesting` formats.

Related: saltstack/salt-jenkins#257