### PR TITLE
Fix incorrect version comparison

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -321,7 +321,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                     break
         tmp_file.seek(0)
 
-        if sys.version_info > (2,):
+        if sys.version_info.major > 2:
             try:
                 out = tmp_file.read().decode(__salt_system_encoding__)
             except (NameError, UnicodeDecodeError):


### PR DESCRIPTION
In #73 we introduced a check against the python version.

It's supposed to return true only for versions that are 3.x or above but instead it returns true for  2.x.

ex for Python 2.7.12:
```
>>> sys.version_info > (2,)
True
>>> sys.version_info > (3,)
False
```
This bug that this fixes breaks Unicode handling for many cases where a test uses a shell and gets Unicode in the response.