### PR TITLE
Prevent crashes if Python version < 2.7

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -321,7 +321,7 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixIn):
                     break
         tmp_file.seek(0)
 
-        if sys.version_info.major > 2:
+        if sys.version_info >= (3,):
             try:
                 out = tmp_file.read().decode(__salt_system_encoding__)
             except (NameError, UnicodeDecodeError):


### PR DESCRIPTION
This PR fixes crashes if using Python 2.6 version.

These errors occurs because `sys.version_info` returns a tuple in Python 2.6.

Doc: https://docs.python.org/2/library/sys.html#sys.version_info