### PR TITLE
Tests on Windows with Jenkins

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -788,6 +788,7 @@ def prepare_winexe_access(options):
     setattr(options, 'win_password', win_password)
 
     # Update git repos
+    print_bulleted(options, 'Update winrepo.')
     cmd = 'salt-run winrepo.update_git_repos'
     run_command(cmd, options, stream_stdout=False, stream_stderr=False)
 
@@ -1657,15 +1658,16 @@ def build_default_test_command(options):
         test_command.append('--ssh')
     if options.test_without_coverage is False and options.test_with_new_coverage is False:
         if options.windows:
-            test_command.append('--coverage-xml=%TEMP%\\coverage.xml')
+            test_command.append('--coverage-xml="\'"\'%TEMP%\\coverage.xml\'"\'"')
         else:
             test_command.append('--coverage-xml=/tmp/coverage.xml')
     if options.no_color:
         test_command.append('--no-color')
     if options.windows:
-        test_command.append('--names-file=\\{0}\\tests\\whitelist.txt' \
-                            ''.format(options.package_source_dir))
-        test_command.append('--xml=%TEMP%\\xml-unittests-output')
+        test_command.append(
+            '--names-file="\'"\'\\{0}\\tests\\whitelist.txt\'"\'"'
+            ''.format(options.package_source_dir))
+        test_command.append('--xml="\'"\'%TEMP%\\xml-unittests-output\'"\'"')
     else:
         test_command.append('--xml=/tmp/xml-unittests-output')
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1069,7 +1069,7 @@ def check_win_minion_connected(options):
                     'Failed to return a ping from the minion. Exit code: {0}'
                     ''.format(exitcode), 'RED'
                 )
-                if retries >= 12:
+                if retries > 12:
                     sys.exit(exitcode)
 
             if not stdout.strip():
@@ -1077,7 +1077,7 @@ def check_win_minion_connected(options):
                     options,
                     'Failed to return a ping from the minion (no output).',
                     'RED')
-                if retries >= 12:
+                if retries > 12:
                     sys.exit(1)
 
             try:
@@ -1093,7 +1093,7 @@ def check_win_minion_connected(options):
                     'Failed to load any JSON from {0!r}'.format(stdout.strip()),
                     'RED')
 
-                if retries < 12:
+                if retries <= 12:
                     print_bulleted(
                         options,
                         'Trying again in 5 seconds. Retry {0}'.format(retries),
@@ -1118,7 +1118,7 @@ def check_win_minion_connected(options):
                         'Failed to reboot the minion. Exit code: {0}'
                         ''.format(exitcode), 'RED'
                     )
-                    if retries >= 12:
+                    if retries > 12:
                         sys.exit(1)
 
                 if not stdout.strip():
@@ -1126,7 +1126,7 @@ def check_win_minion_connected(options):
                         options,
                         'Failed to reboot the minion (no output).',
                         'RED')
-                    if retries >= 12:
+                    if retries > 12:
                         sys.exit(1)
 
                 try:
@@ -1170,7 +1170,7 @@ def check_win_minion_connected(options):
                 print_bulleted(options, 'ATTENTION!!!!', 'YELLOW')
                 print_bulleted(options, 'The minion did not return.', 'YELLOW')
 
-                if retries < 12:
+                if retries <= 12:
                     print_bulleted(
                         options,
                         'Trying again in 5 seconds. Retry {0}'
@@ -1199,7 +1199,7 @@ def check_win_minion_connected(options):
                 'Failed to load grains from the minion. Exit code: {0}'
                 ''.format(exitcode),
                 'RED')
-            if retries >= 12:
+            if retries > 12:
                 sys.exit(exitcode)
 
         if not stdout.strip():
@@ -1207,7 +1207,7 @@ def check_win_minion_connected(options):
                 options,
                 'Failed to load grains from the minion (no output).',
                 'RED')
-            if retries >= 12:
+            if retries > 12:
                 sys.exit(1)
 
         try:
@@ -1224,7 +1224,7 @@ def check_win_minion_connected(options):
                 'Failed to load any JSON from {0!r}'.format(stdout.strip()),
                 'RED')
 
-            if retries < 12:
+            if retries <= 12:
                 print_bulleted(
                     options,
                     'Trying again in 5 seconds. Retry {0}'.format(retries),
@@ -1261,7 +1261,7 @@ def check_win_minion_connected(options):
             print_bulleted(options, 'ATTENTION!!!!', 'YELLOW')
             print_bulleted(options, 'The minion did not return.', 'YELLOW')
 
-            if retries < 12:
+            if retries <= 12:
                 print_bulleted(
                     options,
                     'Trying again in 5 seconds. Retries {0}'

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1662,9 +1662,7 @@ def build_default_test_command(options):
     '''
     Construct the command that is sent to the minion to execute the test run
     '''
-    print(getattr(options, 'get_minion_python_executable', 'Not Found'))
     python_bin_path = get_minion_python_executable(options)
-    print(getattr(options, 'get_minion_python_executable', 'Not Found'))
     # This is a pretty naive approach to get the coverage binary path
     coverage_bin_path = python_bin_path.replace('python', 'coverage')
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1010,7 +1010,7 @@ def check_win_minion_connected(options):
         sys.exit(1)
 
     print_bulleted(options, 'Pinging bootstrapped minion ... ')
-    cmd = ['salt', '-t', '100', '--out=json', '-l', options.log_level]
+    cmd = ['salt', '--out=json', '-l', options.log_level]
     if options.no_color:
         cmd.append('--no-color')
     cmd.extend([options.vm_name, 'grains.items'])

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1109,79 +1109,64 @@ def check_win_minion_connected(options):
 
                 else:
 
-                    # Looks like we got a return, check for the path
-                    if 'c:\salt' not in grains[options.vm_name].lower():
+                    cmd = ['salt', '--out=json', '-l', options.log_level]
+                    cmd.extend([options.vm_name, 'system.reboot', '0', True])
 
-                        cmd = ['salt', '--out=json', '-l', options.log_level]
-                        cmd.extend([options.vm_name, 'system.reboot', '0', True])
-
-                        stdout, stderr, exitcode = run_command(
-                            cmd, options, return_output=True,
-                            stream_stdout=False, stream_stderr=False)
-                        if exitcode:
-                            print_bulleted(
-                                options,
-                                'Failed to reboot the minion. Exit code: {0}'
-                                ''.format(exitcode), 'RED'
-                            )
-                            if attempts >= 12:
-                                sys.exit(1)
-
-                        if not stdout.strip():
-                            print_bulleted(
-                                options,
-                                'Failed to reboot the minion (no output).',
-                                'RED')
-                            if attempts >= 12:
-                                sys.exit(1)
-
-                        try:
-                            # Load the return
-                            result = json.loads(stdout.strip())
-                            # It should return True
-                            if result[options.vm_name] is True:
-
-                                print_bulleted(
-                                    options,
-                                    'Rebooting bootstrapped minion ... ')
-                                print_bulleted(
-                                    options, 'Waiting 1 min...')
-
-                                # Set this value to avoid multiple reboots
-                                setattr(
-                                    options,
-                                    'salt_minion_rebooted',
-                                    True
-                                )
-
-                                time.sleep(60)
-
-                            else:
-
-                                # The reboot did not return True
-                                print_bulleted(
-                                    options, 'Reboot failed... ', 'RED')
-
-                            break
-
-                        except (ValueError, TypeError):
-                            print_bulleted(
-                                options,
-                                'Failed to load any JSON from {0!r}'
-                                ''.format(stdout.strip()),
-                                'RED')
-
-                    else:
-                        # Found C:\salt in the path, no reboot needed
+                    stdout, stderr, exitcode = run_command(
+                        cmd, options, return_output=True,
+                        stream_stdout=False, stream_stderr=False)
+                    if exitcode:
                         print_bulleted(
                             options,
-                            'Minion does not need to be rebooted... ')
-                        setattr(
-                            options,
-                            'salt_minion_rebooted',
-                            True
+                            'Failed to reboot the minion. Exit code: {0}'
+                            ''.format(exitcode), 'RED'
                         )
+                        if attempts >= 12:
+                            sys.exit(1)
+
+                    if not stdout.strip():
+                        print_bulleted(
+                            options,
+                            'Failed to reboot the minion (no output).',
+                            'RED')
+                        if attempts >= 12:
+                            sys.exit(1)
+
+                    try:
+                        # Load the return
+                        result = json.loads(stdout.strip())
+                        # It should return True
+                        if result[options.vm_name] is True:
+
+                            print_bulleted(
+                                options,
+                                'Rebooting bootstrapped minion ... ')
+                            print_bulleted(
+                                options, 'Waiting 1 min...')
+
+                            # Set this value to avoid multiple reboots
+                            setattr(
+                                options,
+                                'salt_minion_rebooted',
+                                True
+                            )
+
+                            time.sleep(60)
+
+                        else:
+
+                            # The reboot did not return True
+                            print_bulleted(
+                                options, 'Reboot failed... ', 'RED')
+
                         break
+
+                    except (ValueError, TypeError):
+                        print_bulleted(
+                            options,
+                            'Failed to load any JSON from {0!r}'
+                            ''.format(stdout.strip()),
+                            'RED')
 
             except (ValueError, TypeError):
                 print_bulleted(

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1639,19 +1639,14 @@ def download_artifacts_smb(options):
         remote_path = '{0}\\{1}'.format(remote_path_dir, remote_path_file)
 
         try:
+            print_bulleted(options, 'Listing files: {0}'.format(remote_path))
             remote_files = smb_conn.listPath('C$', remote_path)
         except SessionError as exc:
-            if 'STATUS_NO_SUCH_FILE' in exc:
-                print_bulleted(
-                    options,
-                    'File not found: {0}'.format(remote_path),
-                    'YELLOW')
-            else:
-                print_bulleted(
-                    options,
-                    'Unknown error: {0}\n'
-                    'File: {1}'.format(exc, remote_path),
-                    'YELLOW')
+            print_bulleted(
+                options,
+                'Error: {0}\n'
+                'File: {1}'.format(exc, remote_path),
+                'YELLOW')
             continue
 
         for item in remote_files:
@@ -1665,20 +1660,15 @@ def download_artifacts_smb(options):
 
             # Download the file
             try:
+                print_bulleted(options, 'Copying file: {0}'.format(remote_file))
                 with fopen(local_file, 'wb') as _fh:
                     smb_conn.getFile('C$', remote_file, _fh.write)
             except SessionError as exc:
-                if 'STATUS_SHARING_VIOLATION' in exc:
-                    print_bulleted(
-                        options,
-                        'File locked: {0}'.format(remote_path),
-                        'YELLOW')
-                else:
-                    print_bulleted(
-                        options,
-                        'Unknown error: {0}\n'
-                        'File: {1}'.format(exc, remote_path),
-                        'YELLOW')
+                print_bulleted(
+                    options,
+                    'Error: {0}\n'
+                    'File: {1}'.format(exc, remote_path),
+                    'YELLOW')
                 continue
 
             # Set permissions if Using SUDO

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -787,6 +787,10 @@ def prepare_winexe_access(options):
     setattr(options, 'win_username', win_username)
     setattr(options, 'win_password', win_password)
 
+    # Update git repos
+    cmd = 'salt-run winrepo.update_git_repos'
+    run_command(cmd, options, stream_stdout=False, stream_stderr=False)
+
     return win_username, win_password
 
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1157,7 +1157,12 @@ def run_state_on_vm(options, state_name, saltenv=None, timeout=100):
     if options.no_color:
         cmd.append('--no-color')
 
-    return run_ssh_command(options, cmd)
+    if options.windows:
+        exitcode = run_winexe_command(options, cmd)
+    else:
+        exitcode = run_ssh_command(options, cmd)
+
+    return exitcode
 
 
 def check_cloned_reposiory_commit(options):
@@ -1288,7 +1293,7 @@ def run_winexe_command(options, remote_command):
     )
     cmd = 'winexe {0} "{1}"'.format(credentials, remote_command)
     logging_cmd = 'winexe {0} "{1}"'.format(logging_credentials, remote_command)
-    win_cmd(cmd, logging_command=logging_cmd)
+    return win_cmd(cmd, logging_command=logging_cmd)
 
 
 def test_ssh_root_login(options):
@@ -1469,7 +1474,10 @@ def generate_xml_coverage_report(options, exit=True):
             get_minion_python_executable(options),
             coverage_bin_path
         )
-        exitcode = run_ssh_command(options, cmd)
+        if options.windows:
+            exitcode = run_winexe_command(options, cmd)
+        else:
+            exitcode = run_ssh_command(options, cmd)
         if exitcode != 0:
             print_bulleted(
                 options, 'The execution of the test command {0!r} failed'.format(cmd), 'RED'
@@ -1915,10 +1923,12 @@ def main():
 
     # Run the main command using SSH/winexe for realtime output
     if options.test_command:
+
         if options.windows:
             exitcode = run_winexe_command(options, options.test_command)
         else:
             exitcode = run_ssh_command(options, options.test_command)
+
         if exitcode != 0:
             print_bulleted(
                 options, 'The execution of the test command {0!r} failed'.format(options.test_command), 'RED'

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1151,7 +1151,7 @@ def run_state_on_vm(options, state_name, saltenv=None, timeout=100):
     ])
     if saltenv:
         cmd.extend(['saltenv={0}'.format(saltenv)])
-    if options.require_sudo:
+    if options.require_sudo and not options.windows:
         cmd.insert(0, 'sudo')
     if options.no_color:
         cmd.append('--no-color')
@@ -1291,6 +1291,8 @@ def run_winexe_command(options, remote_command):
         win_username,
         host
     )
+    if isinstance(remote_command, list):
+        remote_command = ' '.join(remote_command)
     cmd = 'winexe {0} "{1}"'.format(credentials, remote_command)
     logging_cmd = 'winexe {0} "{1}"'.format(logging_credentials, remote_command)
     print_bulleted(options, 'Running WinEXE command: {0}'.format(logging_cmd))

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1171,11 +1171,15 @@ def run_state_on_vm(options, state_name, saltenv=None, timeout=100):
         cmd.append('--timeout={0}'.format(timeout))
     if options.no_color:
         cmd.append('--no-color')
-    cmd.extend([
-        'state.sls',
-        state_name,
-        'pillar="{0}"'.format(build_pillar_data(options))
-    ])
+    cmd.extend(['state.sls', state_name ])
+    if options.windows:
+        cmd.append(
+            # This needed to get the formatting correct '"'"'C:\temp'"'"'
+            'pillar="{0}"'.format(build_pillar_data(options).replace('\'\'', '\''))
+        )
+    else:
+        cmd.append('pillar="{0}"'.format(build_pillar_data(options)))
+
     if saltenv:
         cmd.extend(['saltenv={0}'.format(saltenv)])
     if options.require_sudo and not options.windows:

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1512,9 +1512,9 @@ def run_winexe_command(options, remote_command):
     )
     if isinstance(remote_command, list):
         remote_command = ' '.join(remote_command)
-    cmd = 'winexe {0} --profile \'cmd /c {1}\'' \
+    cmd = 'winexe {0} \'cmd /c {1}\'' \
           ''.format(credentials, remote_command)
-    logging_cmd = 'winexe {0} --profile \'cmd /c {1}\'' \
+    logging_cmd = 'winexe {0} \'cmd /c {1}\'' \
                   ''.format(logging_credentials, remote_command)
     print_bulleted(options, 'Running WinEXE command: {0}'.format(logging_cmd))
     return win_cmd(cmd, logging_command=logging_cmd)

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1025,7 +1025,7 @@ def check_win_minion_connected(options):
         # If C:\salt is in the path, we don't need to reboot
         print_bulleted(options, 'Pinging bootstrapped minion ... ')
         cmd = ['salt', '--out=json', '-l', options.log_level]
-        cmd.extend([options.vm_name, 'grains.item', 'path'])
+        cmd.extend([options.vm_name, 'grains.get', 'path'])
 
         # Attempt to connect to the new minion, it can take a while with a new
         # install
@@ -1129,8 +1129,7 @@ def check_win_minion_connected(options):
                                 print_bulleted(
                                     options, 'Reboot failed... ', 'RED')
 
-                            # End the while loop
-                            attempts = 13
+                            break
 
                         except (ValueError, TypeError):
                             print_bulleted(
@@ -1149,6 +1148,7 @@ def check_win_minion_connected(options):
                             'salt_minion_rebooted',
                             True
                         )
+                        break
 
             except (ValueError, TypeError):
                 print_bulleted(
@@ -1199,7 +1199,7 @@ def check_win_minion_connected(options):
                 print_bulleted(
                     options, 'The minion did not return. ', 'YELLOW')
 
-                if attempts < 10:
+                if attempts <= 12:
                     print_bulleted(
                         options,
                         'Trying again in 5 seconds. Attempt {0}'
@@ -1231,7 +1231,8 @@ def check_win_minion_connected(options):
                     options,
                     'minion_ip_address',
                     grains[options.vm_name]['ipv4'][0])
-                attempts = 13
+
+                break
 
         except (ValueError, TypeError):
             print_bulleted(

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -917,10 +917,11 @@ def get_minion_python_executable(options):
     ]
     if options.no_color:
         cmd.append('--no-color')
-    cmd.extend([
-        options.vm_name,
-        'grains.get', 'pythonexecutable'
-    ])
+    cmd.append(options.vm_name)
+    if options.windows:
+        cmd.extend(['cmd.which', 'python'])
+    else:
+        cmd.extend(['grains.get', 'pythonexecutable'])
     stdout, stderr, exitcode = run_command(cmd,
                                            options,
                                            return_output=True,
@@ -928,12 +929,17 @@ def get_minion_python_executable(options):
                                            stream_stderr=False)
     if exitcode != 0:
         print_bulleted(
-            options, 'Failed to get the minion python executable. Exit code: {0}'.format(exitcode), 'RED'
-        )
+            options,
+            'Failed to get the minion python executable. Exit code: {0}'
+            ''.format(exitcode),
+            'RED')
         sys.exit(exitcode)
 
     if not stdout.strip():
-        print_bulleted(options, 'Failed to get the minion IP address(no output)', 'RED')
+        print_bulleted(
+            options,
+            'Failed to get the minion python executable (no output)',
+            'RED')
         sys.exit(1)
 
     try:
@@ -945,7 +951,11 @@ def get_minion_python_executable(options):
         save_state(options)
         return python_executable
     except (ValueError, TypeError):
-        print_bulleted(options, 'Failed to load any JSON from {0!r}'.format(stdout.strip()), 'RED')
+        print_bulleted(
+            options,
+            'Failed to load any JSON from {0!r}'
+            ''.format(stdout.strip()),
+            'RED')
 
 
 def delete_cloud_vm(options):
@@ -1671,7 +1681,7 @@ def build_default_test_command(options):
         test_command.append('--no-color')
     if options.windows:
         test_command.append(
-            '--names-file="\'"\'\\{0}\\tests\\whitelist.txt\'"\'"'
+            '--names-file="\'"\'{0}\\tests\\whitelist.txt\'"\'"'
             ''.format(options.package_source_dir))
         test_command.append('--xml="\'"\'%TEMP%\\xml-unittests-output\'"\'"')
     else:

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -978,26 +978,18 @@ def delete_parallels_vm(options):
 
 def check_win_minion_connected(options):
     if 'salt_minion_bootstrapped' not in options:
-        print_bulleted(options, 'Minion not bootstrapped. Not pinging minion.', 'RED')
+        print_bulleted(
+            options, 'Minion not bootstrapped. Not pinging minion.', 'RED')
         sys.exit(1)
 
     print_bulleted(options, 'Pinging bootstrapped minion ... ')
-    cmd = [
-        'salt',
-        '-t', '100',
-        '--out=json',
-        '-l', options.log_level
-    ]
+    cmd = ['salt', '-t', '100', '--out=json', '-l', options.log_level]
     if options.no_color:
         cmd.append('--no-color')
-    cmd.extend([
-        options.vm_name,
-        'test.version'
-    ])
+    cmd.extend([options.vm_name, 'test.version'])
 
-    connected = False
     attempts = 0
-    while not connected and attempts <= 10:
+    while attempts <= 12:
         attempts += 1
         stdout, stderr, exitcode = run_command(cmd,
                                                options,
@@ -1023,11 +1015,16 @@ def check_win_minion_connected(options):
                     options, '\n\nATTENTION!!!!\n', 'YELLOW')
                 print_bulleted(
                     options, 'The minion did not return. ', 'YELLOW')
-                print_flush('\n')
+
                 if attempts < 10:
                     print_bulleted(
-                        options, 'Trying again in 20 seconds.', 'YELLOW')
-                    time.sleep(20)
+                        options,
+                        'Trying again in 5 seconds. Attempt {0}'
+                        ''.format(attempts),
+                        'YELLOW')
+                    time.sleep(5)
+
+                print_flush('\n')
             else:
                 print_bulleted(
                     options,
@@ -1037,7 +1034,7 @@ def check_win_minion_connected(options):
                     options,
                     'bootstrapped_salt_minion_version',
                     SaltStackVersion.parse(version_info[options.vm_name]))
-                connected = True
+                attempts = 13
 
         except (ValueError, TypeError):
             print_bulleted(

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1030,6 +1030,7 @@ def check_win_minion_connected(options):
                     options,
                     'Found Version: {0}'.format(version_info[options.vm_name]),
                     'LIGHT_GREEN')
+                print_flush('\n')
                 setattr(
                     options,
                     'bootstrapped_salt_minion_version',
@@ -1130,7 +1131,9 @@ def run_state_on_vm(options, state_name, saltenv=None, timeout=100):
     '''
     Run a state on the VM
     '''
-    test_ssh_root_login(options)
+    if not options.windows:
+        test_ssh_root_login(options)
+
     cmd = [
         'salt-call',
         '-l', options.log_level,
@@ -1145,7 +1148,6 @@ def run_state_on_vm(options, state_name, saltenv=None, timeout=100):
         'state.sls',
         state_name,
         'pillar="{0}"'.format(build_pillar_data(options))
-
     ])
     if saltenv:
         cmd.extend(['saltenv={0}'.format(saltenv)])
@@ -1273,6 +1275,7 @@ def run_ssh_command(options, remote_command):
 
     # Assemble local and remote parts into final command and return result
     cmd.append(pipes.quote(remote_command))
+    print_bulleted(options, 'Running SSH command: {0}'.format(cmd))
     return run_command(cmd, options)
 
 
@@ -1290,6 +1293,7 @@ def run_winexe_command(options, remote_command):
     )
     cmd = 'winexe {0} "{1}"'.format(credentials, remote_command)
     logging_cmd = 'winexe {0} "{1}"'.format(logging_credentials, remote_command)
+    print_bulleted(options, 'Running WinEXE command: {0}'.format(logging_cmd))
     return win_cmd(cmd, logging_command=logging_cmd)
 
 
@@ -1442,7 +1446,7 @@ def build_default_test_command(options):
     # Append extra and conditional parameters
     pillar = build_pillar_data(options, convert_to_yaml=False)
     git_branch = pillar.get('git_branch', 'develop')
-    if git_branch and git_branch not in('2014.1',):
+    if git_branch and git_branch not in('2014.1',) and not options.windows:
         test_command.append('--ssh')
     if options.test_without_coverage is False and options.test_with_new_coverage is False:
         if options.windows:

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1641,9 +1641,15 @@ def build_default_test_command(options):
             '--parallel-mode',
         ])
 
+    # Append basic command
+    if options.windows:
+        test_command.append(
+            '{0}\\tests\\runtests.py'.format(options.package_source_dir))
+    else:
+        test_command.append(
+            '/{0}/tests/runtests.py'.format(options.package_source_dir))
     # Append basic command parameters
     test_command.extend([
-        '/{0}/tests/runtests.py'.format(options.package_source_dir),
         '-v',
         '--run-destructive',
         '--sysinfo',

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -903,7 +903,10 @@ def get_minion_python_executable(options):
     Get and store the remote minion python executable
     '''
     if 'salt_minion_bootstrapped' not in options:
-        print_bulleted(options, 'Minion not bootstrapped. Not grabbing remote python executable.', 'RED')
+        print_bulleted(
+            options,
+            'Minion not bootstrapped. Not grabbing remote python executable.',
+            'RED')
         sys.exit(1)
     if 'minion_python_executable' in options:
         return options.minion_python_executable
@@ -1630,15 +1633,20 @@ def build_default_test_command(options):
     '''
     Construct the command that is sent to the minion to execute the test run
     '''
+    print(getattr(options, 'get_minion_python_executable', 'Not Found'))
     python_bin_path = get_minion_python_executable(options)
+    print(getattr(options, 'get_minion_python_executable', 'Not Found'))
     # This is a pretty naive approach to get the coverage binary path
     coverage_bin_path = python_bin_path.replace('python', 'coverage')
 
     # Select python executable
     if 'salt_minion_bootstrapped' in options:
-        test_command = [get_minion_python_executable(options)]
+        test_command = [python_bin_path]
     else:
-        print_bulleted(options, 'Minion not bootstrapped. Not grabbing remote python executable.', 'YELLOW')
+        print_bulleted(
+            options,
+            'Minion not bootstrapped. Not grabbing remote python executable.',
+            'YELLOW')
         test_command = ['python']
 
     # Append coverage parameters
@@ -1674,16 +1682,16 @@ def build_default_test_command(options):
         test_command.append('--ssh')
     if options.test_without_coverage is False and options.test_with_new_coverage is False:
         if options.windows:
-            test_command.append('--coverage-xml="\'"\'%TEMP%\\coverage.xml\'"\'"')
+            test_command.append('--coverage-xml="%TEMP%\\coverage.xml"')
         else:
             test_command.append('--coverage-xml=/tmp/coverage.xml')
     if options.no_color:
         test_command.append('--no-color')
     if options.windows:
         test_command.append(
-            '--names-file="\'"\'{0}\\tests\\whitelist.txt\'"\'"'
+            '--names-file="{0}\\tests\\whitelist.txt"'
             ''.format(options.package_source_dir))
-        test_command.append('--xml="\'"\'%TEMP%\\xml-unittests-output\'"\'"')
+        test_command.append('--xml="%TEMP%\\xml-unittests-output"')
     else:
         test_command.append('--xml=/tmp/xml-unittests-output')
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1294,7 +1294,7 @@ def run_winexe_command(options, remote_command):
     if isinstance(remote_command, list):
         remote_command = ' '.join(remote_command)
     cmd = 'winexe {0} "{1}"'.format(credentials, remote_command)
-    logging_cmd = 'winexe {0} "{1}"'.format(logging_credentials, remote_command)
+    logging_cmd = 'winexe {0} \'{1}\''.format(logging_credentials, remote_command)
     print_bulleted(options, 'Running WinEXE command: {0}'.format(logging_cmd))
     return win_cmd(cmd, logging_command=logging_cmd)
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1058,7 +1058,7 @@ def check_win_minion_connected(options):
         # If C:\salt is in the path, we don't need to reboot
         print_bulleted(options, 'Pinging bootstrapped minion ... ')
         cmd = ['salt', '--out=json', '-l', options.log_level]
-        cmd.extend([options.vm_name, 'grains.get', 'path'])
+        cmd.extend([options.vm_name, 'test.ping'])
 
         # Attempt to connect to the new minion, it can take a while with a new
         # install
@@ -1081,21 +1081,20 @@ def check_win_minion_connected(options):
             if not stdout.strip():
                 print_bulleted(
                     options,
-                    'Failed to get minion version (no output).',
+                    'Failed to return a ping from the minion (no output).',
                     'RED')
                 if attempts >= 12:
                     sys.exit(1)
 
             try:
                 # Load the return with JSON
-                grains = json.loads(stdout.strip())
+                ping = json.loads(stdout.strip())
 
                 # 'No response' means the minion isn't connected yet, try again
-                if 'No response' in grains[options.vm_name]:
+                if 'No response' in ping[options.vm_name]:
+                    print_bulleted(options, 'ATTENTION!!!!', 'YELLOW')
                     print_bulleted(
-                        options, '\n\nATTENTION!!!!\n', 'YELLOW')
-                    print_bulleted(
-                        options, 'The minion did not return. ', 'YELLOW')
+                        options, 'The minion did not return.', 'YELLOW')
 
                     if attempts < 10:
                         print_bulleted(
@@ -1139,17 +1138,12 @@ def check_win_minion_connected(options):
                         if result[options.vm_name] is True:
 
                             print_bulleted(
-                                options,
-                                'Rebooting bootstrapped minion ... ')
+                                options, 'Rebooting bootstrapped minion... ')
                             print_bulleted(
                                 options, 'Waiting 1 min...')
 
                             # Set this value to avoid multiple reboots
-                            setattr(
-                                options,
-                                'salt_minion_rebooted',
-                                True
-                            )
+                            setattr(options, 'salt_minion_rebooted', True)
 
                             time.sleep(60)
 
@@ -1212,10 +1206,8 @@ def check_win_minion_connected(options):
             # 'No response' means the minion did not return, try again...
             if 'No response' in grains[options.vm_name]:
 
-                print_bulleted(
-                    options, '\n\nATTENTION!!!!\n', 'YELLOW')
-                print_bulleted(
-                    options, 'The minion did not return. ', 'YELLOW')
+                print_bulleted(options, 'ATTENTION!!!!', 'YELLOW')
+                print_bulleted(options, 'The minion did not return.', 'YELLOW')
 
                 if attempts <= 12:
                     print_bulleted(
@@ -1233,22 +1225,22 @@ def check_win_minion_connected(options):
                 print_bulleted(
                     options,
                     'Found Version: {0}'
-                    ''.format(grains[options.vm_name]['saltversion']),
+                    ''.format(ping [options.vm_name]['saltversion']),
                     'LIGHT_GREEN')
                 print_bulleted(
                     options,
-                    'Found IP: {0}'.format(grains[options.vm_name]['ipv4'][0]),
+                    'Found IP: {0}'.format(ping [options.vm_name]['ipv4'][0]),
                     'LIGHT_GREEN')
                 print_flush('\n')
                 setattr(
                     options,
                     'bootstrapped_salt_minion_version',
                     SaltStackVersion.parse(
-                        grains[options.vm_name]['saltversion']))
+                        ping [options.vm_name]['saltversion']))
                 setattr(
                     options,
                     'minion_ip_address',
-                    grains[options.vm_name]['ipv4'][0])
+                    ping [options.vm_name]['ipv4'][0])
 
                 break
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1492,9 +1492,10 @@ def run_winexe_command(options, remote_command):
     )
     if isinstance(remote_command, list):
         remote_command = ' '.join(remote_command)
-    cmd = 'winexe {0} "cmd /c & {1}"' \
+    cmd = 'winexe {0} \'cmd /c & {1}\'' \
           ''.format(credentials, remote_command)
-    logging_cmd = 'winexe {0} \'{1}\''.format(logging_credentials, remote_command)
+    logging_cmd = 'winexe {0} \'cmd /c & {1}\'' \
+                  ''.format(logging_credentials, remote_command)
     print_bulleted(options, 'Running WinEXE command: {0}'.format(logging_cmd))
     return win_cmd(cmd, logging_command=logging_cmd)
 

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1642,11 +1642,8 @@ def download_artifacts_smb(options):
             print_bulleted(options, 'Listing files: {0}'.format(remote_path))
             remote_files = smb_conn.listPath('C$', remote_path)
         except SessionError as exc:
-            print_bulleted(
-                options,
-                'Error: {0}\n'
-                'File: {1}'.format(exc, remote_path),
-                'YELLOW')
+            print_bulleted(options, 'Error: {0}'.format(exc), 'YELLOW')
+            print_bulleted(options, 'File: {0}'.format(remote_path), 'YELLOW')
             continue
 
         for item in remote_files:
@@ -1664,11 +1661,8 @@ def download_artifacts_smb(options):
                 with fopen(local_file, 'wb') as _fh:
                     smb_conn.getFile('C$', remote_file, _fh.write)
             except SessionError as exc:
-                print_bulleted(
-                    options,
-                    'Error: {0}\n'
-                    'File: {1}'.format(exc, remote_path),
-                    'YELLOW')
+                print_bulleted(options, 'Error: {0}'.format(exc), 'YELLOW')
+                print_bulleted(options, 'File: {0}'.format(remote_file), 'YELLOW')
                 continue
 
             # Set permissions if Using SUDO

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1632,8 +1632,10 @@ def download_artifacts_smb(options):
 
         for item in remote_files:
 
-            remote_file = '{0}\\{1}'.format(remote_path, item)
-            local_file = '{0}\\{1}'.format(local_path, item)
+            remote_file = '{0}\\{1}' \
+                          ''.format(os.path.dirname(remote_path),
+                                    item.get_longname())
+            local_file = '{0}/{1}'.format(local_path, item.get_longname())
 
             # Download the file
             with fopen(local_file, 'wb') as _fh:

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1492,9 +1492,9 @@ def run_winexe_command(options, remote_command):
     )
     if isinstance(remote_command, list):
         remote_command = ' '.join(remote_command)
-    cmd = 'winexe {0} \'cmd /c & {1}\'' \
+    cmd = 'winexe {0} \'cmd /c {1}\'' \
           ''.format(credentials, remote_command)
-    logging_cmd = 'winexe {0} \'cmd /c & {1}\'' \
+    logging_cmd = 'winexe {0} \'cmd /c {1}\'' \
                   ''.format(logging_credentials, remote_command)
     print_bulleted(options, 'Running WinEXE command: {0}'.format(logging_cmd))
     return win_cmd(cmd, logging_command=logging_cmd)

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -468,6 +468,7 @@ def bootstrap_cloud_minion(options):
             setattr(options, 'minion_ip_address', yaml.load(clean_stdout)['public_ips'][0].split()[0].encode())
         except Exception as exc:
             print('Exception encountered when processing bootstrap return for display: {0}'.format(exc))
+            print(clean_stdout)
     return exitcode
 
 
@@ -1063,8 +1064,8 @@ def check_win_minion_connected(options):
 
         # Make sure the minion is connected by returning a ping, then reboot
         print_bulleted(options, 'Pinging bootstrapped minion ... ')
-        cmd = ['salt', '--out=json', '-l', options.log_level]
-        cmd.extend([options.vm_name, 'test.ping'])
+        cmd = ['salt', '--out=json', '-l', options.log_level,
+               options.vm_name, 'test.ping']
 
         # Attempt to connect to the new minion, it can take a while with a new
         # install
@@ -1105,8 +1106,8 @@ def check_win_minion_connected(options):
             if ping[options.vm_name] is True:
 
                 # Returned ping, reboot
-                cmd = ['salt', '--out=json', '-l', options.log_level]
-                cmd.extend([options.vm_name, 'system.reboot', '0', True])
+                cmd = ['salt', '--out=json', '-l', options.log_level,
+                       options.vm_name, 'system.reboot', '0', 'True']
 
                 stdout, stderr, exitcode = run_command(
                     cmd, options, return_output=True,
@@ -1177,8 +1178,8 @@ def check_win_minion_connected(options):
     # This time we're loading all the grains because we want to get the
     # Salt version and the IP
     print_bulleted(options, 'Loading grains from bootstrapped minion... ')
-    cmd = ['salt', '--out=json', '-l', options.log_level]
-    cmd.extend([options.vm_name, 'grains.items'])
+    cmd = ['salt', '--out=json', '-l', options.log_level,
+           options.vm_name, 'grains.items']
 
     retries = 0
     while retries <= 12:
@@ -1222,22 +1223,18 @@ def check_win_minion_connected(options):
             print_bulleted(
                 options,
                 'Found Version: {0}'
-                ''.format(ping [options.vm_name]['saltversion']),
+                ''.format(grains[options.vm_name]['saltversion']),
                 'LIGHT_GREEN')
             print_bulleted(
                 options,
-                'Found IP: {0}'.format(ping [options.vm_name]['ipv4'][0]),
+                'Found IP: {0}'.format(grains[options.vm_name]['ipv4'][0]),
                 'LIGHT_GREEN')
             print_flush('\n')
             setattr(
                 options,
                 'bootstrapped_salt_minion_version',
-                SaltStackVersion.parse(
-                    ping [options.vm_name]['saltversion']))
-            setattr(
-                options,
-                'minion_ip_address',
-                ping [options.vm_name]['ipv4'][0])
+                SaltStackVersion.parse(grains[options.vm_name]['saltversion']))
+            setattr(options, 'minion_ip_address', grains[options.vm_name]['ipv4'][0])
 
             break
 


### PR DESCRIPTION
Adds two parameters:
- `--windows` to designate that this is a Windows minion
- `--update-winrepo` to update the winrepo on the master for the pkg tests and some of the setup states

When the `--windows` switch is passed it will:
- Use winexe in place of ssh
- Use SMB to copy artifacts back to the slave

Adds a reboot after the minion is installed in order for the `salt-call` commands to run.