### PR TITLE
Fix bad logic for "mock_open" in python 2.x versions

### DIFF
--- a/salttesting/mock.py
+++ b/salttesting/mock.py
@@ -104,7 +104,7 @@ if NO_MOCK is False:
         NO_MOCK_REASON = 'you need to upgrade your mock version to >= 0.8.0'
 
 
-if sys.version_info > (2,):
+if sys.version_info >= (3,):
     from mock import mock_open
 else:
     # backport mock_open from the python 3 unittest.mock library so that we can


### PR DESCRIPTION
This PR fixes an issue in a python version comparison when backporting python 3 `unittest.mock` library for `mock_open`.

The current comparison does not backport `mock_open` from python 3 when using version 2.x. This produces issues running unit tests in such python version because the lack of `read`, `readlines` and other related method in the provided `mock_open`.