### PR TITLE
Add substitute kwargs to get around shadowing in integration.ModuleCase.run_function()

### DIFF
--- a/salttesting/case.py
+++ b/salttesting/case.py
@@ -433,6 +433,10 @@ class ModuleCase(TestCase, SaltClientTestCaseMixIn):
         know_to_return_none = (
             'file.chown', 'file.chgrp', 'ssh.recv_known_host'
         )
+        if 'f_arg' in kwargs:
+            kwargs['arg'] = kwargs.pop('f_arg')
+        if 'f_timeout' in kwargs:
+            kwargs['timeout'] = kwargs.pop('f_timeout')
         orig = self.client.cmd(
             minion_tgt, function, arg, timeout=timeout, kwarg=kwargs
         )


### PR DESCRIPTION
This echoes changes made in https://github.com/saltstack/salt/pull/39646.

Now that string kwargs are no longer supported, an alternate way was needed for passing arguments to remote execution functions which accept arguments with names already used in ``integration.ModuleCase.run_function()`` (i.e.  ``arg``, ``timeout``).