### PR TITLE
Fix py3 path for Windows

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -960,7 +960,7 @@ def get_minion_python_executable(options):
         python_executable = python_executable[options.vm_name]
         if options.test_with_python3:
             if options.windows:
-                python_executable = 'C:\\Program Files\\Python35\\python.exe'
+                python_executable = 'C:\\PROGRA~1\\Python35\\python.exe'
             else:
                 python_executable = '/usr/bin/python3'
         if options.windows:


### PR DESCRIPTION
Couldn't find a clean way to quote the filename with a path in it. Used the old 8 char Windows path.