### PR TITLE
Adds the --unit-tests switch in Windows

### DIFF
--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1800,6 +1800,7 @@ def build_default_test_command(options):
         test_command.append(
             '--names-file="{0}\\tests\\whitelist.txt"'
             ''.format(options.package_source_dir))
+        test_command.append('--unit-tests')
     test_command.append('--xml=/tmp/xml-unittests-output')
 
     if options.test_with_bash is True:

--- a/salttesting/jenkins.py
+++ b/salttesting/jenkins.py
@@ -1797,10 +1797,10 @@ def build_default_test_command(options):
     if options.no_color:
         test_command.append('--no-color')
     if options.windows:
-        test_command.append(
+        test_command.extend([
             '--names-file="{0}\\tests\\whitelist.txt"'
-            ''.format(options.package_source_dir))
-        test_command.append('--unit-tests')
+            ''.format(options.package_source_dir),
+            '--unit-tests'])
     test_command.append('--xml=/tmp/xml-unittests-output')
 
     if options.test_with_bash is True:


### PR DESCRIPTION
Adds the `--unit-tests` switch to the Windows command

As a note, jenkins tests have added the `--test-without-coverage` switch so that the unit tests will run.
